### PR TITLE
Glossary toolbar buttons appear black, making the icon not visible issue

### DIFF
--- a/src/glossaryPlugin.ts
+++ b/src/glossaryPlugin.ts
@@ -64,9 +64,9 @@ export class GlossaryPlugin extends Plugin<{runtime?: GlossaryRuntime}> {
   initButtonCommands(theme: string): unknown {
     let image = null;
     if ('light' == theme) {
-      image = DarkThemeIcon;
+      image = LightThemeIcon;      
     } else {
-      image = LightThemeIcon;
+      image = DarkThemeIcon;
     }
     return {
       [`[${image}] Insert Glossary/Acronym`]: new GlossaryCommand(this.runtime),


### PR DESCRIPTION
Issue : Glossary toolbar buttons appear black, making the icon not visible